### PR TITLE
feat: add KubeStellar Console to LLM for Infrastructure Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A list of awesome academic researches and industrial materials about Large Langu
       - [3.3 Infrastructure-as-Code](#33-infrastructure-as-code)
       - [3.4 LLM Training Platform](#34-llm-training-platform)
   * [Contribution](#contribution)
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with LLM-powered infrastructure management, AI-driven incident response, and real-time cluster observability. CNCF Sandbox project.
     + [Contributing to this paper list](#contributing-to-this-paper-list)
 
 ## Introduction


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) uses LLMs for Kubernetes infrastructure management: AI-driven incident response, automated remediation suggestions, and real-time multi-cluster observability. CNCF Sandbox project.\n\n*Happy to adjust description or placement.*